### PR TITLE
Add a Nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+# .envrc
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Output
 Code/__pycache__
 Tests/__pycache__
 Input
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1703200384,
+        "narHash": "sha256-q5j06XOsy0qHOarsYPfZYJPWbTbc8sryRxianlEPJN0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0b3d618173114c64ab666f557504d6982665d328",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,3 +1,4 @@
+# This flake gives you an environment where python and LaTeX are available, with the needed LaTeX packages preinstalled.
 {
   inputs = {
     nixpkgs.url = github:NixOS/nixpkgs/nixos-23.11;
@@ -10,13 +11,18 @@
         pkgs = import nixpkgs {
           inherit system;
         };
-        tex = pkgs.texlive.combine {
-          inherit (pkgs.texlive) scheme-basic enumitem geometry;
+        tex-with-packages = pkgs.texlive.combine {
+          inherit (pkgs.texlive) scheme-basic
+            # LaTeX packages are listed here
+            enumitem geometry;
         };
       in
       {
         defaultPackage = pkgs.mkShell {
-          buildInputs = with pkgs; [ tex python3 ];
+          buildInputs = with pkgs; [
+            tex-with-packages # LaTeX with preinstalled packages
+            python3
+          ];
         };
       }
     );

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,23 @@
+{
+  inputs = {
+    nixpkgs.url = github:NixOS/nixpkgs/nixos-23.11;
+    flake-utils.url = github:numtide/flake-utils;
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachSystem flake-utils.lib.allSystems (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+        tex = pkgs.texlive.combine {
+          inherit (pkgs.texlive) scheme-basic enumitem;
+        };
+      in
+      {
+        defaultPackage = pkgs.mkShell {
+          buildInputs = with pkgs; [ tex python3 ];
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
           inherit system;
         };
         tex = pkgs.texlive.combine {
-          inherit (pkgs.texlive) scheme-basic enumitem;
+          inherit (pkgs.texlive) scheme-basic enumitem geometry;
         };
       in
       {


### PR DESCRIPTION
This adds a `flake.nix` file, that allows users to have a development environment with all the dependencies ready.
It also adds an `.envrc` file to automatically activate it if people install `direnv`, and a `flake.lock` with the hashes of the versions used.